### PR TITLE
Fix coverage target to use php

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary
- replace `-p phpdbg` with `-p php` in the `coverage` target
- keep coverage output behavior unchanged for CI (`coverage.xml`) and local runs (`coverage.html`)

## Motivation
- contributte/contributte#73 tracks removing `phpdbg` from coverage targets across Contributte repositories
- this keeps `contributte/cache` aligned with the org-wide coverage driver migration

## Changes
- update both `coverage` target commands in `Makefile` to call Tester with plain `php`
- verify the generated command with `make -n coverage`

## Testing
- [x] `make -n coverage`
- [ ] Coverage run with installed driver
- [ ] CI passes